### PR TITLE
有一说一，私信api为什么注释掉

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -257,7 +257,7 @@ export default defineUserConfig({
                 '/dev/api/role.md',
                 '/dev/api/member.md',
                 '/dev/api/nft.md',
-                // '/dev/api/personal.md',
+                '/dev/api/personal.md',
                 '/dev/api/resource.md',
                 '/dev/api/event.md',
                 '/dev/api/message.md',


### PR DESCRIPTION
rt